### PR TITLE
Release version 1.0.2

### DIFF
--- a/.github/workflows/versioning.yml
+++ b/.github/workflows/versioning.yml
@@ -11,3 +11,4 @@ jobs:
       - uses: Actions-R-Us/actions-tagger@latest
         with:
           publish_latest_tag: true
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by TMS Bot -->
### Summary by TMS Bot

```markdown
Chore: Enhance Versioning Workflow with GITHUB_TOKEN

- The `actions-tagger` action now utilizes the `GITHUB_TOKEN` for enhanced permission management during tag creation and publishing. This ensures smoother and more secure versioning within the repository. User story: As a developer, I want the versioning workflow to have the necessary permissions to create and publish tags automatically.

> A token bright, a workflow's might,
> 🏷️ Now tagging versions, day and night!
> With GITHUB_TOKEN, clear and keen,
> Our releases flow, a joyful scene! 🎉
```

<!-- end of auto-generated comment: release notes by TMS Bot -->